### PR TITLE
Added client delete as well as node delete

### DIFF
--- a/lambda/main.py
+++ b/lambda/main.py
@@ -20,7 +20,7 @@ import logging
 from base64 import b64decode
 from botocore.exceptions import ClientError
 import boto3
-from chef import ChefAPI, Node, Search
+from chef import ChefAPI, Node, Search, Client
 from chef.exceptions import ChefServerNotFoundError
 
 LOGGER = logging.getLogger()
@@ -71,9 +71,12 @@ def handle(event, _context):
         if len(search) != 0:
             for instance in search:
                 node = Node(instance.object.name)
+                client = Client(instance.object.name)
                 try:
                     node.delete()
-                    LOGGER.info('===SUCCESS===')
+                    LOGGER.info('===Node Delete: SUCCESS===')
+                    client.delete()
+                    LOGGER.info('===Client Delete: SUCCESS===')
                     return True
                 except ChefServerNotFoundError as err:
                     LOGGER.error(err)


### PR DESCRIPTION
When deleting a node, it is good practice to also cleanup the client that was created when the node registered with chef.  If this is missed and a node tries to register with the same client name later, the registration will fail. This is a quick addition to include that functionality
