### PR TITLE
add environment variable supporting different pem files

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ aws kms encrypt --key-id KEY_FROM_STEP_1 --plaintext file://your_private_key.pem
   }
   ```
 
-4. Copy just the CiphertextBlob value into a new file and store it in the same directory as the Lambda function; this is required so it can be packaged up with the function itself. I’ve used encrypted_pem.txt as the file name in my example, given the encrypted object is a certificate and private key, which is commonly name with the .pem file extension.
+4. Copy just the CiphertextBlob value into a new file and store it in the same directory as the Lambda function; this is required so it can be packaged up with the function itself. I’ve used encrypted_PROD_pem.txt as the file name in my example, given the encrypted object is a certificate and private key, which is commonly name with the .pem file extension. Lambda supports environment variables wich we can use to pass diferent CiphertextBlob depending on the account you are working on e.g. dev, staging, prod.
 
 ***Note*** the CiphertextBlob output is base64 encoded by the AWS CLI unless you send the output to a binary file using:
 
@@ -48,7 +48,7 @@ To test decryption, you can try something like this:
 
 ```
 aws --profile <your profile name here> kms decrypt --ciphertext-blob \n
-fileb://<(cat encrypted_pem.txt | base64 -D) --output text \n
+fileb://<(cat encrypted_PROD_pem.txt | base64 -D) --output text \n
 --query Plaintext | base64 -D
 ```
 ***Note*** - On a Mac, use `-D`, on any other *nix environment, use `-d`.

--- a/lambda/main.py
+++ b/lambda/main.py
@@ -45,10 +45,10 @@ def get_instance_id(event):
         LOGGER.error(err)
         return False
 
-def get_pem():
+def get_pem(cipherfile):
     """Decrypt the Ciphertext Blob to get USERNAME's pem file"""
     try:
-        with open('encrypted_pem.txt', 'r') as encrypted_pem:
+        with open('cipherfile', 'r') as encrypted_pem:
             pem_file = encrypted_pem.read()
 
         kms = boto3.client('kms', region_name=REGION)
@@ -61,9 +61,11 @@ def handle(event, _context):
     """Lambda Handler"""
     log_event(event)
 
+    cipherfile = os.environ['CIPHER_FILE']
+
     # If you're using a self signed certificate change
     # the ssl_verify argument to False
-    with chef.ChefAPI(CHEF_SERVER_URL, get_pem(), USERNAME, ssl_verify=VERIFY_SSL):
+    with chef.ChefAPI(CHEF_SERVER_URL, get_pem(cipherfile), USERNAME, ssl_verify=VERIFY_SSL):
         instance_id = get_instance_id(event)
         try:
             search = chef.Search('node', 'ec2_instance_id:' + instance_id)

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -11,3 +11,8 @@
 variable "region" {
   default = "us-west-2"
 }
+
+variable "tags" {
+  type    = "map"
+  default = {}
+}


### PR DESCRIPTION
Instead of having a encrypted pem file hardcoded, this PR introduces a
environment variable CIPHER_FILE that can be used for different accounts
e.g. dev, staging, prod.